### PR TITLE
Add missing function definition

### DIFF
--- a/common/pcie_common.h
+++ b/common/pcie_common.h
@@ -161,6 +161,8 @@ void hailo_pcie_read_atr_table(struct hailo_resource *bridge_config, struct hail
 
 void hailo_soc_write_soc_connect(struct hailo_pcie_resources *resources);
 
+bool hailo_pcie_is_device_ready_for_boot(struct hailo_pcie_resources *resources);
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Compiling v4.18.0 from source ends in an error because of a missing function definition in `pcie_common.h`. This PR adds the missing define.

```
jpmeijers@jpmeijers-desktop:~/hailort-drivers$ git checkout master
Previous HEAD position was f840b62 v4.17.0 (#14)
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
jpmeijers@jpmeijers-desktop:~/hailort-drivers$ git pull
Already up to date.
jpmeijers@jpmeijers-desktop:~/hailort-drivers/linux/pcie$ git describe --exact-match --tags
v4.18.0
jpmeijers@jpmeijers-desktop:~/hailort-drivers$ cd linux/pcie/
jpmeijers@jpmeijers-desktop:~/hailort-drivers/linux/pcie$ make all
make[1]: Entering directory '/usr/src/linux-headers-6.8.0-1004-raspi'
warning: the compiler differs from the one used to build the kernel
  The kernel was built by: aarch64-linux-gnu-gcc-13 (Ubuntu 13.2.0-23ubuntu4) 13.2.0
  You are using:           gcc-13 (Ubuntu 13.2.0-23ubuntu4) 13.2.0
  CC [M]  /home/jpmeijers/hailort-drivers/linux/pcie/src/pcie.o
  CC [M]  /home/jpmeijers/hailort-drivers/linux/pcie/src/fops.o
  CC [M]  /home/jpmeijers/hailort-drivers/linux/pcie/src/utils.o
  CC [M]  /home/jpmeijers/hailort-drivers/linux/pcie/src/sysfs.o
  CC [M]  /home/jpmeijers/hailort-drivers/linux/pcie/../../common/fw_validation.o
  CC [M]  /home/jpmeijers/hailort-drivers/linux/pcie/../../common/fw_operation.o
  CC [M]  /home/jpmeijers/hailort-drivers/linux/pcie/../../common/pcie_common.o
/home/jpmeijers/hailort-drivers/linux/pcie/../../common/pcie_common.c:659:6: error: no previous prototype for ‘hailo_pcie_is_device_ready_for_boot’ [-Werror=missing-prototypes]
  659 | bool hailo_pcie_is_device_ready_for_boot(struct hailo_pcie_resources *resources)
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[3]: *** [scripts/Makefile.build:243: /home/jpmeijers/hailort-drivers/linux/pcie/../../common/pcie_common.o] Error 1
make[2]: *** [/usr/src/linux-headers-6.8.0-1004-raspi/Makefile:1926: /home/jpmeijers/hailort-drivers/linux/pcie] Error 2
make[1]: *** [Makefile:240: __sub-make] Error 2
make[1]: Leaving directory '/usr/src/linux-headers-6.8.0-1004-raspi'
make: *** [Makefile:93: all] Error 2
```

Also mentioned on the forum: https://community.hailo.ai/t/cant-install-hailo-rt-pcie-driver-4-17-0-all-deb/1697/8?u=hailo1
