### PR TITLE
Fix compilation on kernel version 6.4.0

### DIFF
--- a/linux/utils/compact.h
+++ b/linux/utils/compact.h
@@ -29,7 +29,7 @@
 #define pci_dbg(pdev, fmt, arg...)	dev_dbg(&(pdev)->dev, fmt, ##arg)
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
 #define get_user_pages_compact get_user_pages
 #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
 #define get_user_pages_compact(start, nr_pages, gup_flags, pages) \


### PR DESCRIPTION
This change fixes the compilation on opensuse 15.6 and kernel 6.4.0-150600.21-default. Before I got the error message

compact.h:36:5: error: too many arguments to function ‘get_user_pages’