### PR TITLE
Support creation of RPM packages for RHEL and CentOS Stream

### DIFF
--- a/hailo-drivers.spec
+++ b/hailo-drivers.spec
@@ -1,0 +1,85 @@
+%global module hailo_pci
+
+%global kernel 5.14.0-587.el9
+%global baserelease 1
+
+%global debug_package %{nil}
+
+%global __spec_install_post \
+  %{?__debug_package:%{__debug_install_post}} \
+  %{__arch_install_post} \
+  %{__os_install_post} \
+  %{__mod_compress_install_post}
+
+%global __mod_compress_install_post find %{buildroot}/lib/modules -type f -name \*.ko -exec xz  --compress --check=crc32 --lzma2=dict=1MiB \{\} \\;
+
+
+Name:             hailort-drivers
+Version:          4.21.0
+Release:          %{baserelease}%{?dist}
+Summary:          Hailo8 PCIe driver
+
+License:          GPLv2
+URL:              https://github.com/hailo-ai/hailort-drivers
+Source0:          https://github.com/hailo-ai/hailort/releases/%{name}-%{version}.tar.gz
+Source1:          hailo8_fw.%{version}.bin
+
+Patch1:           hailo-rhel9.patch
+
+ExclusiveArch:    x86_64 aarch64
+
+BuildRequires:    gcc
+BuildRequires:    kernel-rpm-macros
+BuildRequires:    kmod
+BuildRequires:    make
+BuildRequires:    redhat-rpm-config
+BuildRequires:    xz
+
+BuildRequires:    kernel-abi-stablelists = %{kernel}
+BuildRequires:    kernel-devel-uname-r = %{kernel}.%{_arch}
+
+Requires:         kernel-uname-r >= %{kernel}.%{_arch}
+
+Provides:         installonlypkg(kernel-module)
+Provides:         kernel-modules >= %{kernel}.%{_arch}
+
+Requires(post):   %{_sbindir}/depmod
+
+
+%description
+The Hailo8 PCIe driver is necessary for interacting with a Hailo8 device over the PCIe interface. It connects the HailoRT library to the device and loads the device's firmware when using this interface. The driver is responsible for managing the Hailo device, communicating with it, and transferring data to and from the device.
+
+%prep
+%setup -q -n %{name}
+%patch1 -p1
+
+%build
+pushd linux/pcie
+%{__make} all
+popd
+
+%install
+%{__install} -D -t %{buildroot}/lib/modules/%{kernel}.%{_arch}/extra/misc linux/pcie/%{module}.ko
+mkdir -p %{buildroot}/lib/firmware/hailo
+%{__install} %{SOURCE1} %{buildroot}/lib/firmware/hailo/hailo8_fw.bin
+%{__install} -D -t %{buildroot}/etc/udev/rules.d/ linux/pcie/51-hailo-udev.rules
+
+# Make .ko objects temporarily executable for automatic stripping
+find %{buildroot}/lib/modules -type f -name \*.ko -exec chmod u+x \{\} \+
+
+%clean
+%{__rm} -rf %{buildroot}
+
+%post
+depmod -a
+
+%files
+%defattr(644,root,root,755)
+/lib/modules/%{kernel}.%{_arch}
+/etc/udev/rules.d/51-hailo-udev.rules
+/lib/firmware/hailo/hailo8_fw.bin
+%license LICENSE
+
+%changelog
+* Tue Jun 03 2025 Sebastian Hetze <shetze@redhat.com>
+- initial build

--- a/hailo-rhel9.patch
+++ b/hailo-rhel9.patch
@@ -1,0 +1,53 @@
+diff --git a/linux/utils/compact.h b/linux/utils/compact.h
+index 209e735..1c29b83 100644
+--- a/linux/utils/compact.h
++++ b/linux/utils/compact.h
+@@ -10,7 +10,7 @@
+ #include <linux/scatterlist.h>
+ #include <linux/vmalloc.h>
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 4, 0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4)
+ #define class_create_compat class_create
+ #else
+ #define class_create_compat(name) class_create(THIS_MODULE, name)
+@@ -29,7 +29,7 @@
+ #define pci_dbg(pdev, fmt, arg...)	dev_dbg(&(pdev)->dev, fmt, ##arg)
+ #endif
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 5, 0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4)
+ #define get_user_pages_compact get_user_pages
+ #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 9, 0)
+ #define get_user_pages_compact(start, nr_pages, gup_flags, pages) \
+@@ -68,7 +68,7 @@ static inline void mmap_read_unlock(struct mm_struct *mm)
+ }
+ #endif /* _LINUX_MMAP_LOCK_H */
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 10, 0) && LINUX_VERSION_CODE < KERNEL_VERSION(5, 15, 0) &! RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5)
+ #define sg_alloc_table_from_pages_segment_compat __sg_alloc_table_from_pages
+ #else
+ static inline struct scatterlist *sg_alloc_table_from_pages_segment_compat(struct sg_table *sgt,
+@@ -91,6 +91,8 @@ static inline struct scatterlist *sg_alloc_table_from_pages_segment_compat(struc
+ 
+ #if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+     res = sg_alloc_table_from_pages_segment(sgt, pages, n_pages, offset, size, max_segment, gfp_mask);
++#elif RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 5)
++    res = sg_alloc_table_from_pages_segment(sgt, pages, n_pages, offset, size, max_segment, gfp_mask);
+ #elif LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
+     res = __sg_alloc_table_from_pages(sgt, pages, n_pages, offset, size, max_segment, gfp_mask);
+ #else
+diff --git a/linux/vdma/memory.c b/linux/vdma/memory.c
+index 7ad4a68..7a58154 100644
+--- a/linux/vdma/memory.c
++++ b/linux/vdma/memory.c
+@@ -34,7 +34,7 @@ static void clear_sg_table(struct sg_table *sgt);
+ #define DMA_NS_NAME "DMA_BUF"
+ #endif // LINUX_VERSION_CODE < KERNEL_VERSION(6, 13, 0)
+ 
+-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0) || RHEL_RELEASE_CODE >= RHEL_RELEASE_VERSION(9, 4)
+ // Import DMA_BUF namespace for needed kernels
+ MODULE_IMPORT_NS(DMA_NS_NAME);
+ #endif /* LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0) */


### PR DESCRIPTION
This PR adds a spec file and a RHEL 9 specific patch to support the creation of a hailort-drivers RPM package for RHEL and CentOS Stream distributions.