### PR TITLE
Surround call to find_vma with mmap_read_lock and mmap_read_unlock.

### DIFF
--- a/linux/vdma/memory.c
+++ b/linux/vdma/memory.c
@@ -167,7 +167,9 @@ struct hailo_vdma_buffer *hailo_vdma_buffer_map(struct device *dev,
     }
 
     if (HAILO_DMA_DMABUF_BUFFER != buffer_type) {
+        mmap_read_lock(current->mm);
         vma = find_vma(current->mm, addr_or_fd);
+        mmap_read_unlock(current->mm);
         if (IS_ENABLED(HAILO_SUPPORT_MMIO_DMA_MAPPING)) {
             if (NULL == vma) {
                 dev_err(dev, "no vma for virt_addr/size = 0x%08lx/0x%08zx\n", addr_or_fd, size);


### PR DESCRIPTION
the hailo8 branch (v4.23.0) causes the journal log to become flooded with warning due to the missing `mmap_read_lock` and `mmap_read_unlock` required around `find_vma` This PR mirrors the master branch implementation with regard to this issue. 