### PR TITLE
fix(vdma): fix monitor for kernel 6.15+ (del_timer_sync -> timer_delete_sync)

### DIFF
--- a/linux/vdma/monitor.c
+++ b/linux/vdma/monitor.c
@@ -50,5 +50,5 @@ long hailo_vdma_monitor_start(struct hailo_vdma_monitor *monitor)
 
 void hailo_vdma_monitor_stop(struct hailo_vdma_monitor *monitor)
 {
-    del_timer_sync(&monitor->timer);
+    timer_delete_sync(&monitor->timer);
 }


### PR DESCRIPTION
The `del_timer_sync` compatibility wrapper got deleted in Kernel 6.15 and must be replaced with `timer_delete_sync`

See: https://github.com/torvalds/linux/commit/8fa7292fee5c5240402371ea89ab285ec856c916

This fixes DKMS compilation problems with current RPi kernels.