### PR TITLE
fix(vdma): build on kernel >= 6.16 (del_timer_sync removed)

### DIFF
--- a/linux/utils/compact.h
+++ b/linux/utils/compact.h
@@ -93,5 +93,15 @@ static inline void *kvmalloc_array(size_t n, size_t size, gfp_t flags)
 #define kvfree vfree
 #endif
 
+// del_timer_sync() was renamed to timer_delete_sync() in kernel 6.2, and the
+// legacy del_timer_sync() wrapper was removed entirely in kernel 6.16. Use the
+// new name where it exists so the module builds on >= 6.16 kernels (e.g. the
+// Raspberry Pi 6.18 kernel) while remaining compatible with older ones.
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 2, 0)
+#define del_timer_sync_compat timer_delete_sync
+#else
+#define del_timer_sync_compat del_timer_sync
+#endif
+
 
 #endif /* _HAILO_PCI_COMPACT_H_ */

--- a/linux/vdma/monitor.c
+++ b/linux/vdma/monitor.c
@@ -5,6 +5,7 @@
 
 #include "logs.h"
 #include "vdma.h"
+#include "utils/compact.h"
 
 #include "monitor.h"
 
@@ -50,5 +51,5 @@ long hailo_vdma_monitor_start(struct hailo_vdma_monitor *monitor)
 
 void hailo_vdma_monitor_stop(struct hailo_vdma_monitor *monitor)
 {
-    del_timer_sync(&monitor->timer);
+    del_timer_sync_compat(&monitor->timer);
 }


### PR DESCRIPTION
## Problem

Building the PCIe driver fails on recent kernels (reproduced on the Raspberry Pi `6.18.33+rpt-rpi-2712` kernel):

\`\`\`
../vdma/monitor.c: In function 'hailo_vdma_monitor_stop':
../vdma/monitor.c:53:5: error: implicit declaration of function 'del_timer_sync' [-Wimplicit-function-declaration]
   53 |     del_timer_sync(&monitor->timer);
      |     ^~~~~~~~~~~~~~
\`\`\`

`del_timer_sync()` was renamed to `timer_delete_sync()` in Linux 6.2, and the legacy `del_timer_sync()` wrapper was **removed entirely in Linux 6.16**. On kernels >= 6.16 the call is an implicit declaration, which is fatal under the driver's `-Werror`.

## Fix

- Add a version-gated `del_timer_sync_compat` macro to `linux/utils/compact.h` (alongside the existing kernel-compat shims): maps to `timer_delete_sync()` on kernels >= 6.2 and to `del_timer_sync()` on older kernels.
- Use `del_timer_sync_compat()` in `linux/vdma/monitor.c`, and include `utils/compact.h` there (same include path already used by `linux/vdma/memory.c`).

Both `hailo1x_pci` and `hailo_integrated_nnc` compile `monitor.o`, so the fix covers both modules. No behavior change on supported kernels — only the symbol name is selected by kernel version.

## Testing

- Builds cleanly under `-Werror` on kernel 7.0 (exercises the `timer_delete_sync` branch).
- Confirmed building successfully on the Raspberry Pi `6.18.33+rpt-rpi-2712` kernel where the error originally occurred.

---

This fix was authored by Claude (Anthropic's Claude Code) under my supervision and review.