### PR TITLE
pcie: fix fw_control timeout on platforms where power_mode_enabled() returns false (Allwinner A733)

### DIFF
--- a/linux/pcie/src/fops.c
+++ b/linux/pcie/src/fops.c
@@ -214,15 +214,18 @@ int hailo_pcie_fops_release(struct inode *inode, struct file *filp)
         release_file_context(context);
 
         if (atomic_dec_and_test(&board->ref_count)) {
-            // Disable interrupts
-            hailo_disable_interrupts(board);
-
             if (power_mode_enabled()) {
+                // Disable interrupts before power state change
+                hailo_disable_interrupts(board);
                 hailo_info(board, "Power change state to PCI_D3hot\n");
                 if (board->pDev && pci_set_power_state(board->pDev, PCI_D3hot) < 0) {
                     hailo_err(board, "Failed setting power state to D3hot");
                 }
             }
+            // When power modes are disabled: keep interrupts enabled at last close
+            // so the next fops_open reuses the same MSI IRQ vector instead of
+            // re-registering a new one. Re-registration after pci_disable_msi
+            // breaks fw_control on Allwinner A733.
 
             // deallocate board if already removed
             if (!board->pDev) {

--- a/linux/pcie/src/pcie.c
+++ b/linux/pcie/src/pcie.c
@@ -886,6 +886,9 @@ static int hailo_activate_board(struct hailo_pcie_board *board)
     ktime_t start_time = 0, end_time = 0;
 
     (void)hailo_pcie_disable_aspm(board, PCIE_LINK_STATE_L0S, false);
+    // Also disable L1 — on Allwinner A733 the PCIe link enters L1 after ~40s of
+    // idle, which blocks MSI delivery and causes fw_control to time out.
+    (void)hailo_pcie_disable_aspm(board, PCIE_LINK_STATE_L1, false);
 
     err = hailo_enable_interrupts(board);
     if (err < 0) {
@@ -916,8 +919,8 @@ static int hailo_activate_board(struct hailo_pcie_board *board)
         }
     }
 
-    hailo_disable_interrupts(board);
     if (power_mode_enabled()) {
+        hailo_disable_interrupts(board);
         // Setting the device to low power state, until the user opens the device
         hailo_info(board, "Power change state  to PCI_D3hot\n");
         err = pci_set_power_state(board->pDev, PCI_D3hot);
@@ -926,6 +929,9 @@ static int hailo_activate_board(struct hailo_pcie_board *board)
             return err;
         }
     }
+    // When power modes are disabled: keep interrupts enabled after probe
+    // so fops_open reuses the same MSI IRQ vector instead of reallocating.
+    // Re-allocation after pci_disable_msi breaks fw_control on Allwinner A733.
 
     return 0;
 }


### PR DESCRIPTION
# Fix fw_control timeout on platforms where power_mode_enabled() returns false (ASPM L1 + IRQ reallocation)

## Problem

On Allwinner A733 (and likely other platforms compiled with power modes disabled), `fw_control` times out ~40–50 seconds after boot, causing `Device disconnected` on all subsequent opens. Recovery requires a full reboot.

Root cause is two independent bugs that interact:

### Bug 1: hailo_disable_interrupts() called unconditionally at probe end and at last close

`hailo_activate_board()` in `pcie.c` calls `hailo_disable_interrupts()` unconditionally after firmware load. This frees the MSI IRQ. When userspace next opens the device, `hailo_enable_interrupts()` is called, which calls `pci_enable_msi()` and gets a **different IRQ vector**. On some SoCs (confirmed on Allwinner A733) re-registering MSI after `pci_disable_msi` breaks interrupt routing and the firmware's completion interrupt for `fw_control` is never received.

The same pattern repeats in `hailo_pcie_fops_release()` in `fops.c`: when `ref_count` reaches 0, `hailo_disable_interrupts()` is called unconditionally (even when power modes are disabled), freeing the IRQ. The next `fops_open` gets yet another IRQ vector.

Both locations already have the correct pattern for `pci_set_power_state(D3hot)` — gated by `power_mode_enabled()`. The `hailo_disable_interrupts()` call should use the same gate.

### Bug 2: ASPM L1 not disabled

`hailo_activate_board()` disables ASPM L0s but not L1. On Allwinner A733, both L0s and L1 are active by default. After ~40 seconds of idle PCIe traffic, the link enters L1 power-down. The firmware generates an MSI completion interrupt for the incoming `fw_control` command, but the interrupt cannot be delivered while the link is in L1, causing the 1000ms timeout.

`hailo_pcie_disable_aspm()` already supports `PCIE_LINK_STATE_L1` — it just needs to be called.

## Fix

**`pcie.c`** — two changes:
1. Add `hailo_pcie_disable_aspm(board, PCIE_LINK_STATE_L1, false)` in `hailo_activate_board()`
2. Move `hailo_disable_interrupts()` inside the `power_mode_enabled()` block in `hailo_activate_board()`

**`fops.c`** — one change:
3. Move `hailo_disable_interrupts()` inside the `power_mode_enabled()` block in `hailo_pcie_fops_release()`

## Testing

Tested on Allwinner A733 (Radxa Cubie A7A), kernel 6.18.35 (Armbian), hailo_pci 4.21.0, Hailo8L, Frigate NVR 0.17.1. Before these fixes: `fw_control` timeout on every boot. After: stable operation, object detection running continuously.

The ASPM L1 fix is the primary fix. The IRQ reallocation fix is a prerequisite that ensures MSI routing remains consistent across open/close cycles when power modes are disabled.
