### PR TITLE
Fix install_dkms: skip common/include copy when absent

### DIFF
--- a/linux/pcie/Makefile
+++ b/linux/pcie/Makefile
@@ -135,9 +135,12 @@ endif
 	$(Q)cp -r $(VDMA_SRC_DIRECTORY) /usr/src/$(DRIVER_NAME_NO_EXT)-$(DRIVER_VERSION)/hailort/drivers/linux
 	$(Q)cp -r $(UTILS_SRC_DIRECTORY) /usr/src/$(DRIVER_NAME_NO_EXT)-$(DRIVER_VERSION)/hailort/drivers/linux
 
-# Copy common headers
+# Copy common headers (only present in the internal monorepo layout; this
+# standalone repo ships common/*.h flat, already copied above)
+ifneq ($(wildcard $(COMMON_INCLUDE_DIRECTORY)),)
 	$(Q)mkdir -p /usr/src/$(DRIVER_NAME_NO_EXT)-$(DRIVER_VERSION)/common
 	$(Q)cp -r $(COMMON_INCLUDE_DIRECTORY) /usr/src/$(DRIVER_NAME_NO_EXT)-$(DRIVER_VERSION)/common
+endif
 
 	$(Q)sed 's/@PCIE_DRIVER_VERSION@/$(DRIVER_VERSION)/g' dkms.conf.in > /usr/src/$(DRIVER_NAME_NO_EXT)-$(DRIVER_VERSION)/dkms.conf
 	$(Q)dkms add -m $(DRIVER_NAME_NO_EXT) -v $(DRIVER_VERSION)


### PR DESCRIPTION
## Summary
- `linux/pcie/Makefile`'s `install_dkms` target unconditionally does `cp -r $(COMMON_INCLUDE_DIRECTORY) ...`, where `COMMON_INCLUDE_DIRECTORY=../../../../common/include`. That path only exists in the internal Hailo monorepo layout; this standalone repo ships `common/*.h` flat (already copied a few lines above via `COMMON_SRC_DIRECTORY`).
- As a result, `sudo make install_dkms` always fails on a fresh clone of this repo with `cp: cannot stat '../../../../common/include': No such file or directory`, and DKMS is never registered.
- This change makes the copy conditional on the directory actually existing, so the target succeeds in both layouts.

## Test plan
- [x] `sudo make install_dkms` in `linux/pcie` on Ubuntu, kernel 7.0.0-29-generic, completes successfully and registers with DKMS (`dkms status` shows `hailo_pci/4.24.0 ... installed`)
- [x] Reloaded the module (`modprobe -r/modprobe`) and confirmed `hailortcli fw-control identify` talks to a Hailo-8 device through the DKMS-built module